### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/web/amplify/backend/auth/iotdashboardbce44907/iotdashboardbce44907-cloudformation-template.yml
+++ b/web/amplify/backend/auth/iotdashboardbce44907/iotdashboardbce44907-cloudformation-template.yml
@@ -261,7 +261,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole


### PR DESCRIPTION
CloudFormation templates in aws-appsync-iot-core-realtime-dashboard have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.